### PR TITLE
Add labels to cardlist CSV

### DIFF
--- a/cards/generic/cardlist.csv
+++ b/cards/generic/cardlist.csv
@@ -1,240 +1,204 @@
-image
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/0.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/3.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/4.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/5.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/6.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/7.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/8.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/9.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/10.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/11.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/12.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/13.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/14.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/15.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/16.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/17.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/18.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/19.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/20.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/j1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/j2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/plus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/minus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/stop.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/cancel.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/x.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/0.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/3.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/4.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/5.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/6.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/7.pngimage
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/0.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/3.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/4.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/5.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/6.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/7.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/8.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/9.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/10.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/11.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/12.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/13.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/14.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/15.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/16.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/17.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/18.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/19.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/20.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/j1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/j2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/plus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/minus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/stop.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/cancel.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/x.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/blank.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/0.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/3.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/4.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/5.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/6.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/7.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/8.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/9.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/10.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/11.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/12.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/13.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/14.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/15.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/16.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/17.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/18.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/19.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/20.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/j1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/j2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/plus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/minus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/stop.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/cancel.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/x.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/blank.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/0.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/3.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/4.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/5.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/6.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/7.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/8.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/9.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/10.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/11.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/12.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/13.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/14.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/15.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/16.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/17.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/18.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/19.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/20.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/j1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/j2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/plus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/minus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/stop.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/cancel.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/x.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/blank.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/0.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/3.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/4.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/5.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/6.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/7.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/8.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/9.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/10.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/11.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/12.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/13.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/14.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/15.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/16.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/17.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/18.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/19.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/20.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/j1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/j2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/plus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/minus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/stop.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/cancel.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/x.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/blank.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/0.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/3.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/4.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/5.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/6.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/7.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/8.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/9.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/10.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/11.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/12.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/13.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/14.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/15.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/16.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/17.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/18.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/19.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/20.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/j1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/j2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/plus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/minus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/stop.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/cancel.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/x.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/blank.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/0.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/3.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/4.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/5.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/6.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/7.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/8.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/9.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/10.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/11.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/12.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/13.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/14.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/15.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/16.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/17.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/18.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/19.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/20.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/j1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/j2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/plus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/minus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/stop.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/cancel.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/x.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/blank.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/0.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/3.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/4.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/5.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/6.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/7.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/8.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/9.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/10.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/11.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/12.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/13.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/14.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/15.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/16.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/17.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/18.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/19.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/20.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/j1.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/j2.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/plus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/minus.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/stop.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/cancel.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/x.png
-https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/blank.png
+image,label,item-count
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/0.png,Green Zero,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/1.png,Green 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/2.png,Green 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/3.png,Green 3,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/4.png,Green 4,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/5.png,Green 5,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/6.png,Green 6,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/7.png,Green 7,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/8.png,Green 8,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/9.png,Green 9,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/10.png,Green 10,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/11.png,Green 11,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/12.png,Green 12,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/13.png,Green 13,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/14.png,Green 14,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/15.png,Green 15,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/16.png,Green 16,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/17.png,Green 17,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/18.png,Green 18,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/19.png,Green 19,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/20.png,Green 20,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/j1.png,Green Joker 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/j2.png,Green Joker 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/plus.png,Green Plus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/minus.png,Green Minus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/stop.png,Green Stop,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/cancel.png,Green Cancel,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/x.png,Green X,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/green/blank.png,Green,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/0.png,Blue Zero,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/1.png,Blue 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/2.png,Blue 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/3.png,Blue 3,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/4.png,Blue 4,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/5.png,Blue 5,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/6.png,Blue 6,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/7.png,Blue 7,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/8.png,Blue 8,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/9.png,Blue 9,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/10.png,Blue 10,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/11.png,Blue 11,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/12.png,Blue 12,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/13.png,Blue 13,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/14.png,Blue 14,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/15.png,Blue 15,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/16.png,Blue 16,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/17.png,Blue 17,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/18.png,Blue 18,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/19.png,Blue 19,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/20.png,Blue 20,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/j1.png,Blue Joker 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/j2.png,Blue Joker 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/plus.png,Blue Plus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/minus.png,Blue Minus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/stop.png,Blue Stop,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/cancel.png,Blue Cancel,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/x.png,Blue X,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/blue/blank.png,Blue,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/0.png,Orange Zero,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/1.png,Orange 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/2.png,Orange 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/3.png,Orange 3,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/4.png,Orange 4,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/5.png,Orange 5,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/6.png,Orange 6,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/7.png,Orange 7,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/8.png,Orange 8,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/9.png,Orange 9,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/10.png,Orange 10,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/11.png,Orange 11,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/12.png,Orange 12,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/13.png,Orange 13,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/14.png,Orange 14,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/15.png,Orange 15,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/16.png,Orange 16,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/17.png,Orange 17,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/18.png,Orange 18,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/19.png,Orange 19,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/20.png,Orange 20,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/j1.png,Orange Joker 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/j2.png,Orange Joker 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/plus.png,Orange Plus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/minus.png,Orange Minus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/stop.png,Orange Stop,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/cancel.png,Orange Cancel,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/x.png,Orange X,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/orange/blank.png,Orange,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/0.png,Yellow Zero,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/1.png,Yellow 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/2.png,Yellow 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/3.png,Yellow 3,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/4.png,Yellow 4,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/5.png,Yellow 5,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/6.png,Yellow 6,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/7.png,Yellow 7,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/8.png,Yellow 8,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/9.png,Yellow 9,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/10.png,Yellow 10,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/11.png,Yellow 11,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/12.png,Yellow 12,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/13.png,Yellow 13,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/14.png,Yellow 14,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/15.png,Yellow 15,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/16.png,Yellow 16,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/17.png,Yellow 17,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/18.png,Yellow 18,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/19.png,Yellow 19,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/20.png,Yellow 20,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/j1.png,Yellow Joker 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/j2.png,Yellow Joker 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/plus.png,Yellow Plus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/minus.png,Yellow Minus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/stop.png,Yellow Stop,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/cancel.png,Yellow Cancel,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/x.png,Yellow X,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/yellow/blank.png,Yellow,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/0.png,Red Zero,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/1.png,Red 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/2.png,Red 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/3.png,Red 3,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/4.png,Red 4,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/5.png,Red 5,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/6.png,Red 6,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/7.png,Red 7,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/8.png,Red 8,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/9.png,Red 9,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/10.png,Red 10,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/11.png,Red 11,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/12.png,Red 12,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/13.png,Red 13,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/14.png,Red 14,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/15.png,Red 15,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/16.png,Red 16,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/17.png,Red 17,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/18.png,Red 18,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/19.png,Red 19,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/20.png,Red 20,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/j1.png,Red Joker 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/j2.png,Red Joker 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/plus.png,Red Plus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/minus.png,Red Minus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/stop.png,Red Stop,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/cancel.png,Red Cancel,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/x.png,Red X,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/red/blank.png,Red,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/0.png,Black Zero,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/1.png,Black 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/2.png,Black 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/3.png,Black 3,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/4.png,Black 4,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/5.png,Black 5,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/6.png,Black 6,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/7.png,Black 7,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/8.png,Black 8,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/9.png,Black 9,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/10.png,Black 10,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/11.png,Black 11,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/12.png,Black 12,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/13.png,Black 13,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/14.png,Black 14,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/15.png,Black 15,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/16.png,Black 16,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/17.png,Black 17,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/18.png,Black 18,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/19.png,Black 19,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/20.png,Black 20,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/j1.png,Black Joker 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/j2.png,Black Joker 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/plus.png,Black Plus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/minus.png,Black Minus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/stop.png,Black Stop,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/cancel.png,Black Cancel,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/x.png,Black X,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/black/blank.png,Black,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/0.png,Magenta Zero,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/1.png,Magenta 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/2.png,Magenta 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/3.png,Magenta 3,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/4.png,Magenta 4,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/5.png,Magenta 5,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/6.png,Magenta 6,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/7.png,Magenta 7,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/8.png,Magenta 8,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/9.png,Magenta 9,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/10.png,Magenta 10,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/11.png,Magenta 11,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/12.png,Magenta 12,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/13.png,Magenta 13,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/14.png,Magenta 14,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/15.png,Magenta 15,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/16.png,Magenta 16,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/17.png,Magenta 17,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/18.png,Magenta 18,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/19.png,Magenta 19,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/20.png,Magenta 20,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/j1.png,Magenta Joker 1,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/j2.png,Magenta Joker 2,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/plus.png,Magenta Plus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/minus.png,Magenta Minus,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/stop.png,Magenta Stop,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/cancel.png,Magenta Cancel,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/x.png,Magenta X,1
+https://raw.githubusercontent.com/crazylegs/games/master/cards/generic/magenta/blank.png,Magenta,1


### PR DESCRIPTION
To format the file nicely on GitHub, the first line of the CSV needs a comma in it (needs to be more than one field). And playingcards.io suggests "label" and "item-count" values for its exports of custom decks, added in here to have nice labels after importing.

Also corrected what appears to be a copy/paste error, where part of the file was duplicated